### PR TITLE
Cancel throttled onScroll and React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-component-infinite-scroll",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "React Component for Infinite Scrolling in a page",
   "main": "infinite.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "jsdom": "^8.1.0",
-    "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.7",
-    "react-dom": "^0.14.7",
+    "react": "^15.0.0",
+    "react-addons-test-utils": "^15.0.0",
+    "react-dom": "^15.0.0",
     "sinon": "^1.17.3",
     "tape": "^4.5.1",
     "tape-catch": "^1.0.4"

--- a/src/infinite.jsx
+++ b/src/infinite.jsx
@@ -3,11 +3,6 @@ import ReactDOM from 'react-dom';
 import throttle from 'lodash.throttle';
 
 class InfiniteScroll extends Component {
-  static propTypes = {
-    children: React.PropTypes.node,
-    nextPage: React.PropTypes.func.isRequired,
-    threshold: React.PropTypes.number
-  };
   componentDidMount() {
     this.throttledScroll = throttle(this.onScroll.bind(this), 500);
     window.addEventListener('scroll', this.throttledScroll, false);
@@ -20,6 +15,7 @@ class InfiniteScroll extends Component {
   componentWillUnmount() {
     window.removeEventListener('scroll', this.throttledScroll, false);
     window.removeEventListener('resize', this.throttledScroll, false);
+    this.throttledScroll.cancel();
   }
   onScroll() {
     const windowBottom = window.scrollY + window.innerHeight;
@@ -35,5 +31,15 @@ class InfiniteScroll extends Component {
     return Children.only(children);
   }
 }
+
+InfiniteScroll.propTypes = {
+  children: React.PropTypes.node,
+  nextPage: React.PropTypes.func.isRequired,
+  threshold: React.PropTypes.number
+};
+
+InfiniteScroll.defaultProps = {
+  threshold : 600
+};
 
 export default InfiniteScroll;


### PR DESCRIPTION
onScrol func can be executed despite component being unmounted already. ReactDOM.findDOMNode was erring randomly for me because of the race condition created. Updated package.json, propTypes, and defaultProps to React 15 standards.
